### PR TITLE
Addressableラッパー

### DIFF
--- a/Assets/AddressableAssetsData.meta
+++ b/Assets/AddressableAssetsData.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 22fd8de35d451f94cb74e9fa14207eb8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AddressableAssetsData/AddressableAssetGroupSortSettings.asset
+++ b/Assets/AddressableAssetsData/AddressableAssetGroupSortSettings.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dea69d41f90c6ea4fa55c27c1d60c145, type: 3}
+  m_Name: AddressableAssetGroupSortSettings
+  m_EditorClassIdentifier: 
+  sortOrder:
+  - 94500c83257dade4bbb48f14ed173d53

--- a/Assets/AddressableAssetsData/AddressableAssetGroupSortSettings.asset.meta
+++ b/Assets/AddressableAssetsData/AddressableAssetGroupSortSettings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 28086d824a037c44fb6db458be1597f6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AddressableAssetsData/AddressableAssetSettings.asset
+++ b/Assets/AddressableAssetsData/AddressableAssetSettings.asset
@@ -1,0 +1,114 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 468a46d0ae32c3544b7d98094e6448a9, type: 3}
+  m_Name: AddressableAssetSettings
+  m_EditorClassIdentifier: 
+  m_DefaultGroup: 94500c83257dade4bbb48f14ed173d53
+  m_currentHash:
+    serializedVersion: 2
+    Hash: 00000000000000000000000000000000
+  m_OptimizeCatalogSize: 0
+  m_BuildRemoteCatalog: 0
+  m_CatalogRequestsTimeout: 0
+  m_DisableCatalogUpdateOnStart: 0
+  m_InternalIdNamingMode: 0
+  m_InternalBundleIdMode: 1
+  m_AssetLoadMode: 0
+  m_BundledAssetProviderType:
+    m_AssemblyName: 
+    m_ClassName: 
+  m_AssetBundleProviderType:
+    m_AssemblyName: 
+    m_ClassName: 
+  m_IgnoreUnsupportedFilesInBuild: 0
+  m_UniqueBundleIds: 0
+  m_EnableJsonCatalog: 0
+  m_NonRecursiveBuilding: 1
+  m_CCDEnabled: 0
+  m_maxConcurrentWebRequests: 3
+  m_UseUWRForLocalBundles: 0
+  m_BundleTimeout: 0
+  m_BundleRetryCount: 0
+  m_BundleRedirectLimit: -1
+  m_SharedBundleSettings: 0
+  m_SharedBundleSettingsCustomGroupIndex: 0
+  m_ContiguousBundles: 1
+  m_StripUnityVersionFromBundleBuild: 0
+  m_DisableVisibleSubAssetRepresentations: 0
+  m_BuiltInBundleNaming: 0
+  mBuiltInBundleCustomNaming: 
+  m_MonoScriptBundleNaming: 0
+  m_CheckForContentUpdateRestrictionsOption: 0
+  m_MonoScriptBundleCustomNaming: 
+  m_RemoteCatalogBuildPath:
+    m_Id: 
+  m_RemoteCatalogLoadPath:
+    m_Id: 
+  m_ContentStateBuildPathProfileVariableName: 
+  m_CustomContentStateBuildPath: 
+  m_ContentStateBuildPath: 
+  m_BuildAddressablesWithPlayerBuild: 0
+  m_overridePlayerVersion: '[UnityEditor.PlayerSettings.bundleVersion]'
+  m_GroupAssets:
+  - {fileID: 11400000, guid: 785c077a419655b4cbed4e68986ae5a2, type: 2}
+  m_BuildSettings:
+    m_LogResourceManagerExceptions: 1
+    m_BundleBuildPath: Temp/com.unity.addressables/AssetBundles
+  m_ProfileSettings:
+    m_Profiles:
+    - m_InheritedParent: 
+      m_Id: fddbfad3f69dff14da10fb8a287a23a8
+      m_ProfileName: Default
+      m_Values:
+      - m_Id: 1c4f81a49c6874046aaaf1d275f21413
+        m_Value: '[UnityEditor.EditorUserBuildSettings.activeBuildTarget]'
+      - m_Id: 3ce834a42926edd4993ef5e04e1004ba
+        m_Value: '{UnityEngine.AddressableAssets.Addressables.RuntimePath}/[BuildTarget]'
+      - m_Id: 9c2407bd6f44834469ad6e84fef023a4
+        m_Value: <undefined>
+      - m_Id: b79e3d6af494fc34e975714a5fd8d9d0
+        m_Value: 'ServerData/[BuildTarget]'
+      - m_Id: e10b4ef9ee4dabf4a94bd1683f78b9ab
+        m_Value: '[UnityEngine.AddressableAssets.Addressables.BuildPath]/[BuildTarget]'
+    m_ProfileEntryNames:
+    - m_Id: 1c4f81a49c6874046aaaf1d275f21413
+      m_Name: BuildTarget
+      m_InlineUsage: 0
+    - m_Id: 3ce834a42926edd4993ef5e04e1004ba
+      m_Name: Local.LoadPath
+      m_InlineUsage: 0
+    - m_Id: 9c2407bd6f44834469ad6e84fef023a4
+      m_Name: Remote.LoadPath
+      m_InlineUsage: 0
+    - m_Id: b79e3d6af494fc34e975714a5fd8d9d0
+      m_Name: Remote.BuildPath
+      m_InlineUsage: 0
+    - m_Id: e10b4ef9ee4dabf4a94bd1683f78b9ab
+      m_Name: Local.BuildPath
+      m_InlineUsage: 0
+    m_ProfileVersion: 1
+  m_LabelTable:
+    m_LabelNames:
+    - default
+  m_SchemaTemplates: []
+  m_GroupTemplateObjects:
+  - {fileID: 11400000, guid: 735c42a5549515244b9c804118af7c53, type: 2}
+  m_InitializationObjects: []
+  m_CertificateHandlerType:
+    m_AssemblyName: 
+    m_ClassName: 
+  m_ActivePlayerDataBuilderIndex: 2
+  m_DataBuilders:
+  - {fileID: 11400000, guid: 564a7579099aa5641b969c11f9dd494a, type: 2}
+  - {fileID: 11400000, guid: edbdc43ca93902c439156bbf230f16e8, type: 2}
+  - {fileID: 11400000, guid: 3dbf939c2b7842747a6a2fa46f31ea1b, type: 2}
+  m_ActiveProfileId: fddbfad3f69dff14da10fb8a287a23a8

--- a/Assets/AddressableAssetsData/AddressableAssetSettings.asset.meta
+++ b/Assets/AddressableAssetsData/AddressableAssetSettings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e466d3aebf8022a409ca1b08049e3aed
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AddressableAssetsData/AssetGroupTemplates.meta
+++ b/Assets/AddressableAssetsData/AssetGroupTemplates.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b89973da17fdc654eb2e1be3ec267272
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AddressableAssetsData/AssetGroupTemplates/Packed Assets.asset
+++ b/Assets/AddressableAssetsData/AssetGroupTemplates/Packed Assets.asset
@@ -1,0 +1,78 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-1267631714006125564
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5834b5087d578d24c926ce20cd31e6d6, type: 3}
+  m_Name: ContentUpdateGroupSchema
+  m_EditorClassIdentifier: 
+  m_Group: {fileID: 0}
+  m_StaticContent: 0
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1a3c5d64ac83548c09dd1678b9f6f1cd, type: 3}
+  m_Name: Packed Assets
+  m_EditorClassIdentifier: 
+  m_SchemaObjects:
+  - {fileID: 6020295417812552501}
+  - {fileID: -1267631714006125564}
+  m_Description: Pack assets into asset bundles.
+  m_Settings: {fileID: 11400000, guid: e466d3aebf8022a409ca1b08049e3aed, type: 2}
+--- !u!114 &6020295417812552501
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e5d17a21594effb4e9591490b009e7aa, type: 3}
+  m_Name: BundledAssetGroupSchema
+  m_EditorClassIdentifier: 
+  m_Group: {fileID: 0}
+  m_InternalBundleIdMode: 1
+  m_Compression: 1
+  m_IncludeAddressInCatalog: 1
+  m_IncludeGUIDInCatalog: 1
+  m_IncludeLabelsInCatalog: 1
+  m_InternalIdNamingMode: 0
+  m_CacheClearBehavior: 0
+  m_IncludeInBuild: 1
+  m_BundledAssetProviderType:
+    m_AssemblyName: 
+    m_ClassName: 
+  m_ForceUniqueProvider: 0
+  m_UseAssetBundleCache: 1
+  m_UseAssetBundleCrc: 1
+  m_UseAssetBundleCrcForCachedBundles: 1
+  m_UseUWRForLocalBundles: 0
+  m_Timeout: 0
+  m_ChunkedTransfer: 0
+  m_RedirectLimit: -1
+  m_RetryCount: 0
+  m_BuildPath:
+    m_Id: 
+  m_LoadPath:
+    m_Id: 
+  m_BundleMode: 0
+  m_AssetBundleProviderType:
+    m_AssemblyName: 
+    m_ClassName: 
+  m_UseDefaultSchemaSettings: 0
+  m_SelectedPathPairIndex: 0
+  m_BundleNaming: 0
+  m_AssetLoadMode: 0

--- a/Assets/AddressableAssetsData/AssetGroupTemplates/Packed Assets.asset.meta
+++ b/Assets/AddressableAssetsData/AssetGroupTemplates/Packed Assets.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 735c42a5549515244b9c804118af7c53
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AddressableAssetsData/AssetGroups.meta
+++ b/Assets/AddressableAssetsData/AssetGroups.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3d46bb5df8bcc5b4ca5ced6ae941667e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AddressableAssetsData/AssetGroups/Default Local Group.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Default Local Group.asset
@@ -1,0 +1,28 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bbb281ee3bf0b054c82ac2347e9e782c, type: 3}
+  m_Name: Default Local Group
+  m_EditorClassIdentifier: 
+  m_GroupName: Default Local Group
+  m_GUID: 94500c83257dade4bbb48f14ed173d53
+  m_SerializeEntries:
+  - m_GUID: bb5c7fca326da7b4ba01341d1f0dc8cd
+    m_Address: Still/still0001
+    m_ReadOnly: 0
+    m_SerializedLabels: []
+    FlaggedDuringContentUpdateRestriction: 0
+  m_ReadOnly: 0
+  m_Settings: {fileID: 11400000, guid: e466d3aebf8022a409ca1b08049e3aed, type: 2}
+  m_SchemaSet:
+    m_Schemas:
+    - {fileID: 11400000, guid: b10fa50bc98ea4a4f9cb43ec77b1672a, type: 2}
+    - {fileID: 11400000, guid: f0f1370a19dbfe7428284b26be3041ff, type: 2}

--- a/Assets/AddressableAssetsData/AssetGroups/Default Local Group.asset.meta
+++ b/Assets/AddressableAssetsData/AssetGroups/Default Local Group.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 785c077a419655b4cbed4e68986ae5a2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AddressableAssetsData/AssetGroups/Schemas.meta
+++ b/Assets/AddressableAssetsData/AssetGroups/Schemas.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5f98c72d442c72d409339ed76a65e8ed
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AddressableAssetsData/AssetGroups/Schemas/Default Local Group_BundledAssetGroupSchema.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Schemas/Default Local Group_BundledAssetGroupSchema.asset
@@ -1,0 +1,47 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e5d17a21594effb4e9591490b009e7aa, type: 3}
+  m_Name: Default Local Group_BundledAssetGroupSchema
+  m_EditorClassIdentifier: 
+  m_Group: {fileID: 11400000, guid: 785c077a419655b4cbed4e68986ae5a2, type: 2}
+  m_InternalBundleIdMode: 1
+  m_Compression: 1
+  m_IncludeAddressInCatalog: 1
+  m_IncludeGUIDInCatalog: 1
+  m_IncludeLabelsInCatalog: 1
+  m_InternalIdNamingMode: 0
+  m_CacheClearBehavior: 0
+  m_IncludeInBuild: 1
+  m_BundledAssetProviderType:
+    m_AssemblyName: Unity.ResourceManager, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    m_ClassName: UnityEngine.ResourceManagement.ResourceProviders.BundledAssetProvider
+  m_ForceUniqueProvider: 0
+  m_UseAssetBundleCache: 1
+  m_UseAssetBundleCrc: 1
+  m_UseAssetBundleCrcForCachedBundles: 1
+  m_UseUWRForLocalBundles: 0
+  m_Timeout: 0
+  m_ChunkedTransfer: 0
+  m_RedirectLimit: -1
+  m_RetryCount: 0
+  m_BuildPath:
+    m_Id: e10b4ef9ee4dabf4a94bd1683f78b9ab
+  m_LoadPath:
+    m_Id: 3ce834a42926edd4993ef5e04e1004ba
+  m_BundleMode: 0
+  m_AssetBundleProviderType:
+    m_AssemblyName: Unity.ResourceManager, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    m_ClassName: UnityEngine.ResourceManagement.ResourceProviders.AssetBundleProvider
+  m_UseDefaultSchemaSettings: 0
+  m_SelectedPathPairIndex: 0
+  m_BundleNaming: 0
+  m_AssetLoadMode: 0

--- a/Assets/AddressableAssetsData/AssetGroups/Schemas/Default Local Group_BundledAssetGroupSchema.asset.meta
+++ b/Assets/AddressableAssetsData/AssetGroups/Schemas/Default Local Group_BundledAssetGroupSchema.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b10fa50bc98ea4a4f9cb43ec77b1672a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AddressableAssetsData/AssetGroups/Schemas/Default Local Group_ContentUpdateGroupSchema.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Schemas/Default Local Group_ContentUpdateGroupSchema.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5834b5087d578d24c926ce20cd31e6d6, type: 3}
+  m_Name: Default Local Group_ContentUpdateGroupSchema
+  m_EditorClassIdentifier: 
+  m_Group: {fileID: 11400000, guid: 785c077a419655b4cbed4e68986ae5a2, type: 2}
+  m_StaticContent: 0

--- a/Assets/AddressableAssetsData/AssetGroups/Schemas/Default Local Group_ContentUpdateGroupSchema.asset.meta
+++ b/Assets/AddressableAssetsData/AssetGroups/Schemas/Default Local Group_ContentUpdateGroupSchema.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f0f1370a19dbfe7428284b26be3041ff
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AddressableAssetsData/DataBuilders.meta
+++ b/Assets/AddressableAssetsData/DataBuilders.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 73d12fbb1ea4c4449879988d2273b640
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AddressableAssetsData/DataBuilders/BuildScriptFastMode.asset
+++ b/Assets/AddressableAssetsData/DataBuilders/BuildScriptFastMode.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 88d21199f5d473f4db36845f2318f180, type: 3}
+  m_Name: BuildScriptFastMode
+  m_EditorClassIdentifier: 
+  instanceProviderType:
+    m_AssemblyName: Unity.ResourceManager, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    m_ClassName: UnityEngine.ResourceManagement.ResourceProviders.InstanceProvider
+  sceneProviderType:
+    m_AssemblyName: Unity.ResourceManager, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    m_ClassName: UnityEngine.ResourceManagement.ResourceProviders.SceneProvider

--- a/Assets/AddressableAssetsData/DataBuilders/BuildScriptFastMode.asset.meta
+++ b/Assets/AddressableAssetsData/DataBuilders/BuildScriptFastMode.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 564a7579099aa5641b969c11f9dd494a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AddressableAssetsData/DataBuilders/BuildScriptPackedMode.asset
+++ b/Assets/AddressableAssetsData/DataBuilders/BuildScriptPackedMode.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3e2e0ffa088c91d41a086d0b8cb16bdc, type: 3}
+  m_Name: BuildScriptPackedMode
+  m_EditorClassIdentifier: 
+  instanceProviderType:
+    m_AssemblyName: Unity.ResourceManager, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    m_ClassName: UnityEngine.ResourceManagement.ResourceProviders.InstanceProvider
+  sceneProviderType:
+    m_AssemblyName: Unity.ResourceManager, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    m_ClassName: UnityEngine.ResourceManagement.ResourceProviders.SceneProvider

--- a/Assets/AddressableAssetsData/DataBuilders/BuildScriptPackedMode.asset.meta
+++ b/Assets/AddressableAssetsData/DataBuilders/BuildScriptPackedMode.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3dbf939c2b7842747a6a2fa46f31ea1b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AddressableAssetsData/DataBuilders/BuildScriptPackedPlayMode.asset
+++ b/Assets/AddressableAssetsData/DataBuilders/BuildScriptPackedPlayMode.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ad8c280d42ee0ed41a27db23b43dd2bf, type: 3}
+  m_Name: BuildScriptPackedPlayMode
+  m_EditorClassIdentifier: 
+  instanceProviderType:
+    m_AssemblyName: Unity.ResourceManager, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    m_ClassName: UnityEngine.ResourceManagement.ResourceProviders.InstanceProvider
+  sceneProviderType:
+    m_AssemblyName: Unity.ResourceManager, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    m_ClassName: UnityEngine.ResourceManagement.ResourceProviders.SceneProvider

--- a/Assets/AddressableAssetsData/DataBuilders/BuildScriptPackedPlayMode.asset.meta
+++ b/Assets/AddressableAssetsData/DataBuilders/BuildScriptPackedPlayMode.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: edbdc43ca93902c439156bbf230f16e8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AddressableAssetsData/DefaultObject.asset
+++ b/Assets/AddressableAssetsData/DefaultObject.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3a189bb168d8d90478a09ea08c2f3d72, type: 3}
+  m_Name: DefaultObject
+  m_EditorClassIdentifier: 
+  m_AddressableAssetSettingsGuid: e466d3aebf8022a409ca1b08049e3aed

--- a/Assets/AddressableAssetsData/DefaultObject.asset.meta
+++ b/Assets/AddressableAssetsData/DefaultObject.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3ae0b8ad127a1fd40a4500befd6eb9b7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AddressableAssetsData/ProfileDataSourceSettings.asset
+++ b/Assets/AddressableAssetsData/ProfileDataSourceSettings.asset
@@ -1,0 +1,28 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7e3976da977cb49238499ea3b4c237ae, type: 3}
+  m_Name: ProfileDataSourceSettings
+  m_EditorClassIdentifier: 
+  profileGroupTypes:
+  - m_GroupTypePrefix: Built-In
+    m_Variables:
+    - m_Suffix: BuildPath
+      m_Value: '[UnityEngine.AddressableAssets.Addressables.BuildPath]/[BuildTarget]'
+    - m_Suffix: LoadPath
+      m_Value: '{UnityEngine.AddressableAssets.Addressables.RuntimePath}/[BuildTarget]'
+  environments: []
+  currentEnvironment:
+    id: 
+    projectId: 
+    projectGenesisId: 
+    name: 
+    isDefault: 0

--- a/Assets/AddressableAssetsData/ProfileDataSourceSettings.asset.meta
+++ b/Assets/AddressableAssetsData/ProfileDataSourceSettings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 16a069dabd8d8a54fafcbcbc5297833b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AddressableAssetsData/Windows.meta
+++ b/Assets/AddressableAssetsData/Windows.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e9204cdd4a6cd48438fdcbeb91d8c63c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Common/Scripts/AssetManagement.meta
+++ b/Assets/Common/Scripts/AssetManagement.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7e70548e185e04a4a95528b4e60da1e2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Common/Scripts/AssetManagement/AssetLifeTime.cs
+++ b/Assets/Common/Scripts/AssetManagement/AssetLifeTime.cs
@@ -1,0 +1,85 @@
+using System;
+using Cysharp.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.ResourceManagement.AsyncOperations;
+using UnityEngine.SceneManagement;
+
+namespace AssetManagement
+{
+    /// <summary>
+    /// アセットのライフタイムをまとめて管理・解放するもの
+    /// </summary>
+    public abstract class AssetLifeTimeBase : IDisposable
+    {
+        private AsyncOperationHandle[]? _handles;
+        private int _count;
+        private bool _isDisposed;
+
+        /// <summary>
+        /// AsyncOperationHandleを追加
+        /// </summary>
+        internal void AddAsyncOperationHandle(AsyncOperationHandle handle)
+        {
+            if (_handles == null)
+            {
+                _handles = new AsyncOperationHandle[4];
+            }
+            else if (_handles.Length == _count)
+            {
+                Array.Resize(ref _handles, _handles.Length * 2);
+            }
+            _handles[_count++] = handle;
+        }
+
+        public void Dispose()
+        {
+            if (_isDisposed) return;
+            _isDisposed = true;
+
+            for (int i = 0; i < _count; i++)
+            {
+                _handles?[i].Release();
+            }
+        }
+    }
+
+    /// <summary>
+    /// アセットのライフタイムを手動でDisposeするまでにする
+    /// </summary>
+    public class AssetLifeTime : AssetLifeTimeBase { }
+
+    /// <summary>
+    /// アセットのライフタイムをゲームオブジェクトに紐づける
+    /// </summary>
+    public class GameObjectLinkedAssetLifeTime : AssetLifeTimeBase
+    {
+        public GameObjectLinkedAssetLifeTime(GameObject gameObject)
+        {
+            gameObject.GetCancellationTokenOnDestroy()
+            .RegisterWithoutCaptureExecutionContext(Dispose);
+        }
+    }
+
+    /// <summary>
+    /// アセットのライフタイムをシーンに紐づける
+    /// </summary>
+    public class SceneLinkedAssetLifeTime : AssetLifeTimeBase
+    {
+        private string _sceneName;
+
+        public SceneLinkedAssetLifeTime(string sceneName)
+        {
+            _sceneName = sceneName;
+            SceneManager.sceneUnloaded += OnSceneUnloaded;
+        }
+
+        private void OnSceneUnloaded(Scene scene)
+        {
+            if (scene.name == _sceneName)
+            {
+                Dispose();
+                SceneManager.sceneUnloaded -= OnSceneUnloaded;
+            }
+        }
+    }
+}

--- a/Assets/Common/Scripts/AssetManagement/AssetLifeTime.cs.meta
+++ b/Assets/Common/Scripts/AssetManagement/AssetLifeTime.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1f87d673fc91a634c8081b1f296937a3

--- a/Assets/Common/Scripts/AssetManagement/AssetLoader.cs
+++ b/Assets/Common/Scripts/AssetManagement/AssetLoader.cs
@@ -3,6 +3,7 @@ using System;
 using System.Threading;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
+using UnityEngine.ResourceManagement.AsyncOperations;
 
 namespace AssetManagement
 {

--- a/Assets/Common/Scripts/AssetManagement/AssetLoader.cs
+++ b/Assets/Common/Scripts/AssetManagement/AssetLoader.cs
@@ -1,0 +1,56 @@
+using Cysharp.Threading.Tasks;
+using System;
+using System.Threading;
+using UnityEngine;
+using UnityEngine.AddressableAssets;
+
+namespace AssetManagement
+{
+    public static class AssetLoader
+    {
+        /// <summary>
+        /// アセットを非同期ロードする
+        /// </summary>
+        public static async UniTask<T?> LoadAsync<T>(string address, AssetLifeTimeBase assetLifeTime, CancellationToken cancellationToken)
+            where T : UnityEngine.Object
+        {
+            var handle = Addressables.LoadAssetAsync<T>(address);
+
+            try
+            {
+                await handle.WithCancellation(cancellationToken);
+
+                // Addressable内部の例外を確認
+                var ex = handle.OperationException;
+                if (ex != null) throw ex.GetBaseException();
+            }
+            catch (OperationCanceledException)
+            {
+                // キャンセルされたら解放してnullを返す
+                Debug.Log("[AssetLoader] ロードがキャンセルされました");
+                handle.Release();
+                return null;
+            }
+            catch
+            {
+                // 例外が発生したら解放して投げ直す
+                handle.Release();
+                throw;
+            }
+
+            // Addressablesの内部エラーがあったかを確認
+            if (handle.Status != UnityEngine.ResourceManagement.AsyncOperations.AsyncOperationStatus.Succeeded)
+            {
+                handle.Release();
+                throw handle.OperationException ?? new Exception("Unknown Exception.");
+            }
+
+            // AssetLifeTimeに追加
+            assetLifeTime.AddAsyncOperationHandle(handle);
+
+            // ロードしたアセットを返す
+            return handle.Result;
+        }
+
+    }
+}

--- a/Assets/Common/Scripts/AssetManagement/AssetLoader.cs
+++ b/Assets/Common/Scripts/AssetManagement/AssetLoader.cs
@@ -20,9 +20,13 @@ namespace AssetManagement
             {
                 await handle.WithCancellation(cancellationToken);
 
-                // Addressable内部の例外を確認
-                var ex = handle.OperationException;
-                if (ex != null) throw ex.GetBaseException();
+                // Addressablesの内部エラーがあったかを確認
+                if (handle.Status != AsyncOperationStatus.Succeeded)
+                {
+                    var ex = handle.OperationException ?? new Exception("Unknown exception occurred while loading asset.");
+                    handle.Release();
+                    throw ex;
+                }
             }
             catch (OperationCanceledException)
             {
@@ -36,13 +40,6 @@ namespace AssetManagement
                 // 例外が発生したら解放して投げ直す
                 handle.Release();
                 throw;
-            }
-
-            // Addressablesの内部エラーがあったかを確認
-            if (handle.Status != UnityEngine.ResourceManagement.AsyncOperations.AsyncOperationStatus.Succeeded)
-            {
-                handle.Release();
-                throw handle.OperationException ?? new Exception("Unknown Exception.");
             }
 
             // AssetLifeTimeに追加

--- a/Assets/Common/Scripts/AssetManagement/AssetLoader.cs
+++ b/Assets/Common/Scripts/AssetManagement/AssetLoader.cs
@@ -25,7 +25,6 @@ namespace AssetManagement
                 if (handle.Status != AsyncOperationStatus.Succeeded)
                 {
                     var ex = handle.OperationException ?? new Exception("Unknown exception occurred while loading asset.");
-                    handle.Release();
                     throw ex;
                 }
             }

--- a/Assets/Common/Scripts/AssetManagement/AssetLoader.cs.meta
+++ b/Assets/Common/Scripts/AssetManagement/AssetLoader.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cb5c20c4d57aa2744992ebaba487ceb2

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -5,6 +5,7 @@
     "com.cysharp.unitask": "https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask",
     "com.cysharp.zlinq": "https://github.com/Cysharp/ZLinq.git?path=src/ZLinq.Unity/Assets/ZLinq.Unity",
     "com.github-glitchenzo.nugetforunity": "https://github.com/GlitchEnzo/NuGetForUnity.git?path=/src/NuGetForUnity",
+    "com.unity.addressables": "2.4.6",
     "com.unity.ai.navigation": "2.0.7",
     "com.unity.collab-proxy": "2.8.2",
     "com.unity.ide.rider": "3.0.36",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -141,7 +141,14 @@
     },
     "com.unity.nuget.mono-cecil": {
       "version": "1.11.4",
-      "depth": 3,
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.profiling.core": {
+      "version": "1.0.2",
+      "depth": 1,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -37,6 +37,22 @@
       "dependencies": {},
       "hash": "d30cb64a988ac3ecfd31bd9dc96e38422a729e47"
     },
+    "com.unity.addressables": {
+      "version": "2.4.6",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.profiling.core": "1.0.2",
+        "com.unity.test-framework": "1.4.5",
+        "com.unity.modules.assetbundle": "1.0.0",
+        "com.unity.modules.jsonserialize": "1.0.0",
+        "com.unity.modules.imageconversion": "1.0.0",
+        "com.unity.modules.unitywebrequest": "1.0.0",
+        "com.unity.scriptablebuildpipeline": "2.3.8",
+        "com.unity.modules.unitywebrequestassetbundle": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.ai.navigation": {
       "version": "2.0.7",
       "depth": 0,


### PR DESCRIPTION
### やったこと
- Addressableの導入
- ラッパーの実装
- プロファイラを使おうとしたらなんかmanifest.jsonに差分が出たっぽいのでその分

ビルド済アセットバンドルを使用してのアセットのロード成功を確認済み
プロファイラで見た所、解放も正常に動いている
カタログも問題なくこれで読めてるようなので、一旦この最小限の構成で様子見

### 使い方
1 AssetLifeTimeを作成する

```
// ex.1 手動でDisposeすることで解放するやつ
private AssetLifeTime _assetLifeTime = new();

// ex. 2 ゲームオブジェクトの破棄と同時に自動解放されるやつ
var assetLifeTime = new GameObjectLinkedAssetLifeTime();
```

2 AssetLoader.LoadAsyncを呼ぶ

```
// ex. コンポーネントでロードするときのイメージ
var sprite = await AssetLoader.LoadAsync<Sprite>(address, assetLifeTime, destroyCancellationToken);
```

3 必要に応じて解放する

```
_assetLifeTime.Dispose();
```

### 備考
Resourcesも使いたい場合は共通化したい感あり
（参照カウンタを作って、参照切れたら自動でResources.UnloadAssetしてやる仕組みをAssetLifeTimeに統合する）